### PR TITLE
fix: Sometimes some tests using a wiremock server are failing in timeout

### DIFF
--- a/src/test/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherTest.java
+++ b/src/test/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherTest.java
@@ -19,6 +19,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.gravitee.fetcher.api.FetcherException;
 import io.vertx.core.Vertx;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -38,8 +39,8 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class BitbucketFetcherTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+    @ClassRule
+    public static final WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
     private BitbucketFetcher fetcher = new BitbucketFetcher(null);
 


### PR DESCRIPTION
fix gravitee-io/issues#2358