### PR TITLE
fix: use url path in client options

### DIFF
--- a/src/test/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherTest.java
+++ b/src/test/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherTest.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/1341

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.1-apim-1341-bitbucket-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-bitbucket/1.7.1-apim-1341-bitbucket-SNAPSHOT/gravitee-fetcher-bitbucket-1.7.1-apim-1341-bitbucket-SNAPSHOT.zip)
  <!-- Version placeholder end -->
