### PR TITLE
Update fetcher for APIM 4.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:lib"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,169 +1,39 @@
-# Created by .ignore support plugin (hsz.mobi)
-### OSX template
-*.DS_Store
-.AppleDouble
-.LSOverride
-
-# Icon must end with two \r
-Icon
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
-### Eclipse template
-
-.metadata
-bin/
-tmp/
-*.tmp
-*.bak
-*.swp
-*~.nib
-local.properties
-.settings/
-.loadpath
-.recommenders
-
-# Eclipse Core
-.project
-
-# External tool builders
-.externalToolBuilders/
-
-# Locally stored "Eclipse launch configurations"
-*.launch
-
-# PyDev specific (Python IDE for Eclipse)
-*.pydevproject
-
-# CDT-specific (C/C++ Development Tooling)
-.cproject
-
-# JDT-specific (Eclipse Java Development Tools)
-.classpath
-
-# Java annotation processor (APT)
-.factorypath
-
-# PDT-specific (PHP Development Tools)
-.buildpath
-
-# sbteclipse plugin
-.target
-
-# Tern plugin
-.tern-project
-
-# TeXlipse plugin
-.texlipse
-
-# STS (Spring Tool Suite)
-.springBeans
-
-# Code Recommenders
-.recommenders/
-### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
-
-*.iml
-
-## File-based project format:
-*.iws
-
-## Plugin-specific files:
-
-# IntelliJ
-/out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
-### Windows template
-# Windows image file caches
-Thumbs.db
-ehthumbs.db
-
-# Folder config file
-Desktop.ini
-
-# Recycle Bin used on file shares
-$RECYCLE.BIN/
-
-# Windows Installer files
-*.cab
-*.msi
-*.msm
-*.msp
-
-# Windows shortcuts
-*.lnk
-### Linux template
-*~
-
-# temporary files which can be created if a process still has a handle open of a deleted file
-.fuse_hidden*
-
-# KDE directory preferences
-.directory
-
-# Linux trash folder which might appear on any partition or disk
-.Trash-*
-
-### Maven template
 target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
-release.properties
-dependency-reduced-pom.xml
-buildNumber.properties
-.mvn/timing.properties
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
 
-gravitee-fetcher-git.iml
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -24,20 +24,22 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>22.0.2</version>
     </parent>
 
     <groupId>io.gravitee.fetcher</groupId>
     <artifactId>gravitee-fetcher-bitbucket</artifactId>
-    <version>1.7.1</version>
+    <version>2.0.0-upgrade-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Fetcher - Bitbucket</name>
 
     <properties>
-        <gravitee-bom.version>1.1</gravitee-bom.version>
-        <gravitee-node-api.version>1.4.6</gravitee-node-api.version>
-        <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <gravitee-bom.version>6.0.39</gravitee-bom.version>
+        <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
+        <gravitee-node-api.version>4.8.6</gravitee-node-api.version>
+        <wiremock.version>3.3.1</wiremock.version>
+
+        <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/fetchers</publish-folder-path>
     </properties>
@@ -56,6 +58,7 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Gravitee.io -->
         <dependency>
             <groupId>io.gravitee.fetcher</groupId>
             <artifactId>gravitee-fetcher-api</artifactId>
@@ -107,10 +110,17 @@
             </exclusions>
         </dependency>
 
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,15 +129,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>2.19.0</version>
-            <scope>test</scope>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -167,19 +177,6 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,12 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/assembly/fetcher-assembly.xml
+++ b/src/assembly/fetcher-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/fetcher/bitbucket/BitbucketFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/bitbucket/BitbucketFetcher.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/fetcher/bitbucket/BitbucketFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/bitbucket/BitbucketFetcher.java
@@ -23,7 +23,6 @@ import io.gravitee.fetcher.api.FetcherException;
 import io.gravitee.fetcher.api.Resource;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.utils.NodeUtils;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -40,7 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.support.CronSequenceGenerator;
+import org.springframework.scheduling.support.CronExpression;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -137,7 +136,7 @@ public class BitbucketFetcher implements Fetcher {
 
         if (bitbucketFetcherConfiguration.isAutoFetch() && bitbucketFetcherConfiguration.getFetchCron() != null) {
             try {
-                new CronSequenceGenerator(bitbucketFetcherConfiguration.getFetchCron());
+                CronExpression.parse(bitbucketFetcherConfiguration.getFetchCron());
             } catch (IllegalArgumentException e) {
                 throw new FetcherException("Cron expression is invalid", e);
             }

--- a/src/main/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherConfiguration.java
+++ b/src/main/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherConfiguration.java
@@ -1,13 +1,11 @@
-package io.gravitee.fetcher.bitbucket;
-
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +13,8 @@ package io.gravitee.fetcher.bitbucket;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.gravitee.fetcher.bitbucket;
+
 import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.Sensitive;
 

--- a/src/main/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherConfiguration.java
+++ b/src/main/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherConfiguration.java
@@ -17,11 +17,15 @@ package io.gravitee.fetcher.bitbucket;
 
 import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.Sensitive;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class BitbucketFetcherConfiguration implements FetcherConfiguration {
 
     private String bitbucketUrl;
@@ -40,94 +44,4 @@ public class BitbucketFetcherConfiguration implements FetcherConfiguration {
     private String fetchCron;
 
     private boolean autoFetch = false;
-
-    @Override
-    public String getFetchCron() {
-        return fetchCron;
-    }
-
-    public void setFetchCron(String fetchCron) {
-        this.fetchCron = fetchCron;
-    }
-
-    @Override
-    public boolean isAutoFetch() {
-        return autoFetch;
-    }
-
-    public void setAutoFetch(boolean autoFetch) {
-        this.autoFetch = autoFetch;
-    }
-
-    public String getBitbucketUrl() {
-        return bitbucketUrl;
-    }
-
-    public void setBitbucketUrl(String bitbucketUrl) {
-        this.bitbucketUrl = bitbucketUrl;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getRepository() {
-        return repository;
-    }
-
-    public void setRepository(String repository) {
-        this.repository = repository;
-    }
-
-    public String getBranchOrTag() {
-        return branchOrTag;
-    }
-
-    public void setBranchOrTag(String branchOrTag) {
-        this.branchOrTag = branchOrTag;
-    }
-
-    public String getFilepath() {
-        return filepath;
-    }
-
-    public void setFilepath(String filepath) {
-        this.filepath = filepath;
-    }
-
-    public String getLogin() {
-        return login;
-    }
-
-    public void setLogin(String login) {
-        this.login = login;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public boolean isUseSystemProxy() {
-        return useSystemProxy;
-    }
-
-    public void setUseSystemProxy(boolean useSystemProxy) {
-        this.useSystemProxy = useSystemProxy;
-    }
-
-    public String getEditLink() {
-        return editLink;
-    }
-
-    public void setEditLink(String editLink) {
-        this.editLink = editLink;
-    }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,80 +1,69 @@
 {
-  "type": "object",
-  "title": "bitbucket",
-  "properties": {
-    "bitbucketUrl": {
-      "title": "Bitbucket api url",
-      "description": "Bitbucket API url (e.g. https://api.bitbucket.org/2.0)",
-      "type": "string",
-      "default": "https://api.bitbucket.org/2.0"
-    },
-    "useSystemProxy": {
-      "title": "Use system proxy",
-      "description": "Use the system proxy configured by your administrator.",
-      "type": "boolean"
-    },
-    "username": {
-      "title": "Username",
-      "description": "Username or organization",
-      "type": "string"
-    },
-    "repository": {
-      "title": "Repository",
-      "description": "Repository name",
-      "type": "string"
-    },
-    "branchOrTag": {
-      "title": "Ref",
-      "description": "Branch name or tag (e.g. master)",
-      "type": "string",
-      "default": "master"
-    },
-    "filepath": {
-      "title": "Filepath",
-      "description": "The path to the file to fetch (e.g. /docs/main/README.md)",
-      "type": "string"
-    },
-    "login": {
-      "title": "Login",
-      "description": "the user login used in basic authentication. See https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#basic-auth",
-      "type": "string"
-    },
-    "password": {
-      "title": "Password",
-      "description": "Use an application password. See https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#app-pw",
-      "type": "string",
-      "x-schema-form": {
-        "type": "password"
-      }
-    },
-    "autoFetch": {
-      "title": "Auto Fetch",
-      "description": "Trigger periodic update",
-      "type": "boolean",
-      "default": false
-    },
-    "fetchCron": {
-      "title": "Update frequency",
-      "description": "Define update frequency using Crontab pattern.<BR><B>Note:</B> Platform administrator may have configure a max frequency that you cannot exceed",
-      "type": "string"
-    }
-  },
-  "required": [
-    "bitbucketUrl",
-    "username",
-    "repository",
-    "branchOrTag",
-    "filepath",
-    "login",
-    "password"
-  ],
-  "if": {
+    "type": "object",
+    "title": "bitbucket",
     "properties": {
-      "autoFetch": { "const": true }
-    }
-  },
-  "then": { "required": ["fetchCron"] }
+        "bitbucketUrl": {
+            "title": "Bitbucket api url",
+            "description": "Bitbucket API url (e.g. https://api.bitbucket.org/2.0)",
+            "type": "string",
+            "default": "https://api.bitbucket.org/2.0"
+        },
+        "useSystemProxy": {
+            "title": "Use system proxy",
+            "description": "Use the system proxy configured by your administrator.",
+            "type": "boolean"
+        },
+        "username": {
+            "title": "Username",
+            "description": "Username or organization",
+            "type": "string"
+        },
+        "repository": {
+            "title": "Repository",
+            "description": "Repository name",
+            "type": "string"
+        },
+        "branchOrTag": {
+            "title": "Ref",
+            "description": "Branch name or tag (e.g. master)",
+            "type": "string",
+            "default": "master"
+        },
+        "filepath": {
+            "title": "Filepath",
+            "description": "The path to the file to fetch (e.g. /docs/main/README.md)",
+            "type": "string"
+        },
+        "login": {
+            "title": "Login",
+            "description": "the user login used in basic authentication. See https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#basic-auth",
+            "type": "string"
+        },
+        "password": {
+            "title": "Password",
+            "description": "Use an application password. See https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#app-pw",
+            "type": "string",
+            "x-schema-form": {
+                "type": "password"
+            }
+        },
+        "autoFetch": {
+            "title": "Auto Fetch",
+            "description": "Trigger periodic update",
+            "type": "boolean",
+            "default": false
+        },
+        "fetchCron": {
+            "title": "Update frequency",
+            "description": "Define update frequency using Crontab pattern.<BR><B>Note:</B> Platform administrator may have configure a max frequency that you cannot exceed",
+            "type": "string"
+        }
+    },
+    "required": ["bitbucketUrl", "username", "repository", "branchOrTag", "filepath", "login", "password"],
+    "if": {
+        "properties": {
+            "autoFetch": { "const": true }
+        }
+    },
+    "then": { "required": ["fetchCron"] }
 }
-
-
-

--- a/src/test/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherTest.java
+++ b/src/test/java/io/gravitee/fetcher/bitbucket/BitbucketFetcherTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4957
https://github.com/gravitee-io/issues/issues/9733

**Description**

Starting with APIM 4.3, Spring 6.1.8 is used. But in this version, the `CronSequenceGenerator` has been replaced by `CronExpression`
We need to update every fetcher libs and plugins to handle this change.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-upgrade-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-bitbucket/2.0.0-upgrade-SNAPSHOT/gravitee-fetcher-bitbucket-2.0.0-upgrade-SNAPSHOT.zip)
  <!-- Version placeholder end -->
